### PR TITLE
Fix cost and scheduling service bug

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1958,6 +1958,8 @@
         <copy todir="${temp.dir}/${scheduling.app.name}${webinf.dir}/resourcing/rsInterface">
             <fileset dir="${classes.dir}${packageRoot}/resourcing/rsInterface"/>
         </copy>
+        <copy todir="${temp.dir}/${scheduling.app.name}${webinf.dir}/resourcing/jsf/comparator"
+              file="${classes.dir}${packageRoot}/resourcing/jsf/comparator/ParticipantNameComparator.class"/>
 
         <copy todir="${temp.dir}/${scheduling.app.name}${webinf.dir}/elements">
             <fileset dir="${classes.dir}${packageRoot}/elements"
@@ -1981,7 +1983,7 @@
             <fileset dir="${classes.dir}${packageRoot}/util"
                      includes="JDOMUtil.class StringUtil.class CharsetFilter.class
                                PasswordEncryptor.class XNode*.class
-                               HibernateEngine.class"/>
+                               HibernateEngine.class HibernateRegistry.class"/>
         </copy>
         <copy todir="${temp.dir}/${scheduling.app.name}${webinf.dir}/engine/interfce">
             <fileset dir="${classes.dir}${packageRoot}/engine/interfce"/>

--- a/src/org/yawlfoundation/yawl/cost/data/CostDriver.hbm.xml
+++ b/src/org/yawlfoundation/yawl/cost/data/CostDriver.hbm.xml
@@ -55,14 +55,14 @@
         <component name="unitCost"
                    class="org.yawlfoundation.yawl.cost.data.UnitCost" access="field"
                    lazy="false">
-            <property name="unit" column="costUnit"/>
+            <property name="unit" column="costUnit" access="field"/>
             <component name="costValue"
                        class="org.yawlfoundation.yawl.cost.data.CostValue" access="field"
                        lazy="false">
                 <property name="amount" column="costValueAmount"/>
                 <property name="currency" column="costValueCurrency"/>
             </component>
-            <property name="facetStatus" type="byte"/>
+            <property name="facetStatus" type="integer"/>
         </component>
 
     </class>

--- a/src/org/yawlfoundation/yawl/cost/data/CostMapping.hbm.xml
+++ b/src/org/yawlfoundation/yawl/cost/data/CostMapping.hbm.xml
@@ -33,7 +33,7 @@
         <component name="cost"
                    class="org.yawlfoundation.yawl.cost.data.MappingIdentifier"
                    access="field" lazy="false">
-            <property name="_type" column="costMappingIDType" type="byte"/>
+            <property name="_type" column="costMappingIDType" type="integer"/>
             <property name="id" column="costID"/>
             <property name="term" column="costTerm"/>
         </component>
@@ -41,12 +41,12 @@
         <component name="workflow"
                    class="org.yawlfoundation.yawl.cost.data.MappingIdentifier"
                    access="field" lazy="false">
-            <property name="_type" column="workflowMappingIDType" type="byte"/>
+            <property name="_type" column="workflowMappingIDType" type="integer"/>
             <property name="id" column="workflowID"/>
             <property name="term" column="workflowTerm"/>
         </component>
 
-        <property name="mappingType" column="mappingType" type="byte"/>
+        <property name="mappingType" column="mappingType" type="integer"/>
 
     </class>
 

--- a/src/org/yawlfoundation/yawl/cost/data/DriverFacet.hbm.xml
+++ b/src/org/yawlfoundation/yawl/cost/data/DriverFacet.hbm.xml
@@ -31,7 +31,7 @@
         </id>
 
         <property name="id" column="internalID" access="field"/>
-        <property name="_facetAspect" column="facetAspect" type="byte"/>
+        <property name="_facetAspect" column="facetAspect" type="integer"/>
         <property name="name" column="entityName" access="field"/>
         <property name="value" column="entityValue" access="field"/>
 

--- a/src/org/yawlfoundation/yawl/cost/data/MappingIdentifier.java
+++ b/src/org/yawlfoundation/yawl/cost/data/MappingIdentifier.java
@@ -61,13 +61,11 @@ public class MappingIdentifier {
 
 
     // for hibernate
-
-    // for hibernate
     private int get_type() {
         return _type != null ? _type.ordinal() : -1;
     }
 
-    private void setFacetStatus(int ordinal) {
+    private void set_type(int ordinal) {
         _type = (ordinal == -1) ? null : MappingIdType.values()[ordinal];
     }
 }

--- a/src/org/yawlfoundation/yawl/cost/log/UnbundledEvent.java
+++ b/src/org/yawlfoundation/yawl/cost/log/UnbundledEvent.java
@@ -59,7 +59,7 @@ class UnbundledEvent {
             else if (key.equals("lifecycle:transition")) {
                 transition = child.getAttributeValue("value");
             }
-            else if (key.equals("lifecycle:instance")) {
+            else if (key.equals("concept:instance")) {
                 instance = child.getAttributeValue("value");
             }
             else if (key.equals("org:resource")) {

--- a/src/org/yawlfoundation/yawl/scheduling/servlet/MessageReceiveServlet.java
+++ b/src/org/yawlfoundation/yawl/scheduling/servlet/MessageReceiveServlet.java
@@ -139,12 +139,12 @@ public class MessageReceiveServlet extends HttpServlet implements Constants {
 
 		try	{
 			String userName = request.getParameter("userName");
+			action = request.getParameter("action");
 			if (! (action.equals("login") ||
                     rs.isValidSession(userName, request.getParameter("sessionHandle")))) {
 				throw new SchedulingException("msgSessionTimeout");
 			}
 
-            action = request.getParameter("action");
 			if (action.equals("login"))	{
 				responseMap.put("loginResponse", paramsMap);
 				String password = request.getParameter("password");


### PR DESCRIPTION
While building API documentation for YAWL 6.1 (bachelor thesis project), I deployed
`costService.war` and `schedulingService.war` from `YAWL-6.1-OptionalServices.zip`
into a standard installer setup (Tomcat 10.1.54, JDK 21, shared H2 via yawllib) and
ran into several defects. I initially reported these with recompiled WARs; as
requested, here are the actual line-level fixes as a PR. All fixes were verified
against a live 6.1 instance.

## Commits

1. **Fix misnamed hibernate setter in `MappingIdentifier`** — the accessor pair added
   in d11aee644 names the getter `get_type()` but the setter `setFacetStatus(int)`
   (apparently copied from `UnitCost`). `CostMapping.hbm.xml` maps property `_type`
   with default access, so session-factory creation fails with a
   `PropertyNotFoundException`, `CostGateway.init()` aborts, and every request
   returns HTTP 500. The init error only shows up in `yawl_engine.log`, which makes
   it easy to miss.

2. **Fix cost service hbm mappings under Hibernate 6** — the enum-ordinal properties
   are mapped `type="byte"` while their accessors get/set `int`; Hibernate 6 no
   longer coerces, so `importModel` fails with `ClassCastException (Integer → Byte)`
   on insert. Changed to `type="integer"`, matching the correction already made to
   `RdrTreeSet.hbm.xml` in 904e7f4aa. `UnitCost.unit` additionally needs
   `access="field"`: the field is a `TimeUnit` enum while the public accessors are
   String-typed, so Hibernate 6 resolves the type via the field and then fails when
   binding the String value.
   *Note:* the same `type="byte"` pattern still exists in `WorkletRunner.hbm.xml`,
   `ExletRunner.hbm.xml`, `LaunchEvent.hbm.xml` and procletService
   `StoredItem.hbm.xml`; I left those untouched because my tests did not cover
   those code paths.

3. **Fix `UnbundledEvent` reading the wrong XES attribute** — it looks for the work
   item instance id under `lifecycle:instance`, but `YXESBuilder` writes it as
   `concept:instance`. `instance` therefore stays null and `getKey()` throws an
   NPE, so `getAnnotatedLog` returns HTTP 500 for every log that contains
   start/complete events.

4. **Fix NPE in `MessageReceiveServlet.handleCUIRequest`** — `action.equals("login")`
   is evaluated before `action = request.getParameter("action")` is assigned, so
   every scheduling-UI request (including `login`) throws an NPE and the generic
   catch returns an empty JSON map.

5. **Package missing classes into `schedulingService.war`** — the build target ships
   `HibernateEngine` without `HibernateRegistry` (→ `NoClassDefFoundError` /
   `LinkageError` on first DB access) and `ResourceGatewayClientAdapter` without
   `ParticipantNameComparator` (→ the class gets loaded from the shared yawl-lib
   instead and casts against the webapp-local `Participant` class:
   `ClassCastException` in `lanes` as soon as two or more participants exist; with
   exactly one participant the comparator is never invoked, so the defect goes
   unnoticed).
